### PR TITLE
fix: Critical idempotency endpoint fixes for Task 4.2 License APIs

### DIFF
--- a/apps/api/app/routers/license.py
+++ b/apps/api/app/routers/license.py
@@ -393,7 +393,7 @@ async def extend_license(
         if idempotency_key:
             await IdempotencyService.store_response(
                 db, idempotency_key, current_user.id, response.dict(),
-                endpoint="/api/v1/license/assign",
+                endpoint="/api/v1/license/extend",
                 method="POST",
                 status_code=200
             )
@@ -539,7 +539,7 @@ async def cancel_license(
         if idempotency_key:
             await IdempotencyService.store_response(
                 db, idempotency_key, current_user.id, response.dict(),
-                endpoint="/api/v1/license/assign",
+                endpoint="/api/v1/license/cancel",
                 method="POST",
                 status_code=200
             )


### PR DESCRIPTION
## Summary
- Fixed critical copy-paste errors in idempotency endpoint tracking for license APIs
- Corrected endpoint paths in `/extend` and `/cancel` operations 

## Changes
### Fixed Idempotency Endpoints
- **Line 396**: Changed endpoint from `/api/v1/license/assign` to `/api/v1/license/extend` for extend operation
- **Line 542**: Changed endpoint from `/api/v1/license/assign` to `/api/v1/license/cancel` for cancel operation

## Context
These were critical bugs where all three license operations (assign, extend, cancel) were incorrectly using the same endpoint path `/api/v1/license/assign` for idempotency tracking. This would cause incorrect behavior when using the Idempotency-Key header, as responses from one operation could be returned for a different operation.

## Testing
- All endpoints now correctly track their own idempotency responses
- Each operation properly stores and retrieves its own cached responses

🤖 Generated with [Claude Code](https://claude.ai/code)