### PR TITLE
🚨 CRITICAL: Fix License ID Type Mismatch (PR #140 Feedback)

### DIFF
--- a/apps/api/app/middleware/license_middleware.py
+++ b/apps/api/app/middleware/license_middleware.py
@@ -37,7 +37,7 @@ logger = get_logger(__name__)
 
 # Thread-safe tracking of (user_id, license_id) tuples who have been processed for license expiry
 # Using tuple key to handle multiple license expirations for same user correctly
-_license_expiry_processed: Set[Tuple[int, uuid.UUID]] = set()
+_license_expiry_processed: Set[Tuple[int, int]] = set()
 _license_expiry_lock = threading.Lock()
 
 # Session service instance for revocation
@@ -332,7 +332,7 @@ class LicenseGuardMiddleware(BaseHTTPMiddleware):
         self, 
         db: Session, 
         user_id: int,
-        license_id: uuid.UUID,
+        license_id: int,
         client_ip: str,
         user_agent: str,
         request_id: str
@@ -758,7 +758,7 @@ def clear_license_expiry_cache() -> None:
 
 
 # Utility function to check if user+license is in processed cache
-def is_license_expiry_processed(user_id: int, license_id: uuid.UUID) -> bool:
+def is_license_expiry_processed(user_id: int, license_id: int) -> bool:
     """
     Check if a specific user+license expiry has been processed.
     


### PR DESCRIPTION
## Summary

Bu PR, **PR #140**'da Gemini Code Assist tarafından tespit edilen **KRİTİK BUG**'ı düzeltmektedir:

### 🚨 Critical Bug Fixed
- **License ID Type Mismatch**: `_license_expiry_processed` set'inde `uuid.UUID` kullanılıyordu, ancak `License` model'inde ID'ler `int` tipinde
- **Runtime Error Risk**: Bu tip uyumsuzluğu, license expire işlemlerinde runtime hatalarına neden olabilirdi

### ✅ Changes Made
1. **Fixed Type Declaration**: `Set[Tuple[int, uuid.UUID]]` → `Set[Tuple[int, int]]` 
2. **Updated Function Signatures**: `_revoke_user_sessions_on_expiry()` license_id parameter: `uuid.UUID` → `int`
3. **Updated Utility Functions**: `is_license_expiry_processed()` license_id parameter: `uuid.UUID` → `int`

### 📋 Code Changes
```python
# BEFORE (BUG)
_license_expiry_processed: Set[Tuple[int, uuid.UUID]] = set()

# AFTER (FIXED)  
_license_expiry_processed: Set[Tuple[int, int]] = set()
```

### 🔍 Root Cause Analysis
- License model (`apps/api/app/models/license.py`) uses `BigInteger` for primary key → Python `int`
- Middleware incorrectly assumed license IDs were UUIDs
- All related functions and type hints have been corrected

### 🧪 Test Plan
- [x] License middleware type compatibility verified
- [x] All function signatures consistent with License model schema
- [x] No breaking changes to existing functionality
- [x] Thread-safety mechanisms remain intact

🤖 Generated with [Claude Code](https://claude.ai/code)