### PR TITLE
fix: Apply PR #181 ClamAV feedback - memory-efficient streaming

### DIFF
--- a/.env.clamav.example
+++ b/.env.clamav.example
@@ -17,7 +17,7 @@ CLAMAV_TIMEOUT_SCAN=60.0
 CLAMAV_MAX_CONCURRENT_SCANS=3
 
 # Security policy - fail closed if true and daemon unreachable
-CLAMAV_SCAN_ENABLED=true
+CLAMAV_FAIL_CLOSED=true
 
-# To disable ClamAV scanning entirely (not recommended in production):
-# CLAMAV_SCAN_ENABLED=false
+# To disable fail-closed mode (allow uploads even if ClamAV is down):
+# CLAMAV_FAIL_CLOSED=false


### PR DESCRIPTION
## Summary
- Fixes memory inefficiency issue identified in PR #181 by Gemini Code Assist
- Streams directly from MinIO to ClamAV without buffering entire file in memory
- Corrects environment variable naming for consistency

## Changes
1. **Remove BytesIO buffer** - Stream directly from MinIO response to ClamAV's `instream()` method
2. **Fix environment variable** - Changed `CLAMAV_SCAN_ENABLED` to `CLAMAV_FAIL_CLOSED` in `.env.clamav.example`
3. **Add proper cleanup** - Ensure MinIO response is always closed in finally block
4. **Fix metrics** - Use `stat.size` instead of `total_bytes` since we're no longer buffering

## Testing
- The MinIO `get_object()` response is file-like and can be passed directly to ClamAV's `instream()` method
- This eliminates memory issues for large files
- Proper connection cleanup prevents resource leaks

Addresses feedback from PR #181: https://github.com/cncaiprojem/projem/pull/181

🤖 Generated with [Claude Code](https://claude.ai/code)