### PR TITLE
fix: Apply ALL PR #181 Gemini and Copilot review feedback (with ClamAV)

### DIFF
--- a/.env.clamav.example
+++ b/.env.clamav.example
@@ -1,0 +1,23 @@
+# ClamAV Configuration for Task 5.6
+# Copy these settings to your .env file
+
+# Enable ClamAV malware scanning
+CLAMAV_ENABLED=true
+
+# ClamAV daemon connection settings
+CLAMAV_HOST=clamd
+CLAMAV_PORT=3310
+# CLAMAV_UNIX_SOCKET=/var/run/clamav/clamd.sock  # Optional Unix socket (preferred over TCP)
+
+# Connection timeouts
+CLAMAV_TIMEOUT_CONNECT=10.0
+CLAMAV_TIMEOUT_SCAN=60.0
+
+# Rate limiting
+CLAMAV_MAX_CONCURRENT_SCANS=3
+
+# Security policy - fail closed if true and daemon unreachable
+CLAMAV_SCAN_ENABLED=true
+
+# To disable ClamAV scanning entirely (not recommended in production):
+# CLAMAV_SCAN_ENABLED=false

--- a/.env.clamav.example
+++ b/.env.clamav.example
@@ -17,7 +17,7 @@ CLAMAV_TIMEOUT_SCAN=60.0
 CLAMAV_MAX_CONCURRENT_SCANS=3
 
 # Security policy - fail closed if true and daemon unreachable
-CLAMAV_SCAN_ENABLED=true
+CLAMAV_FAIL_CLOSED=true
 
-# To disable ClamAV scanning entirely (not recommended in production):
-# CLAMAV_SCAN_ENABLED=false
+# To disable fail-closed mode (allow uploads even if ClamAV is down):
+# CLAMAV_FAIL_CLOSED=false

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -767,7 +767,7 @@
               "5.5"
             ],
             "details": "- clamd: connect via TCP or Unix socket; timeouts 10s connect / 60s scan; stream-scan from MinIO (avoid local disk) using chunk bridge.\n- Scan policy: execute only for configured types (e.g., non-G-code CAD and videos) or if scan_enabled; on detection: delete object, 422 MALWARE_DETECTED with remediation hint.\n- Failure mode: fail closed if scan_enabled=true and clamd unreachable → 503 SCAN_UNAVAILABLE; log security_event.\n- Rate limiting: cap concurrent scans to protect resources.\n- Acceptance tests:\n  - EICAR string upload triggers 422 MALWARE_DETECTED and object removed.\n  - clamd down → finalize returns 503 SCAN_UNAVAILABLE when scan_enabled.\n  - scan_enabled=false → finalize succeeds without scan.",
-            "status": "pending",
+            "status": "in-progress",
             "testStrategy": ""
           },
           {
@@ -1708,7 +1708,7 @@
     ],
     "metadata": {
       "created": "2025-08-15T19:56:57.780Z",
-      "updated": "2025-08-21T07:22:36.650Z",
+      "updated": "2025-08-21T10:16:11.898Z",
       "description": "Tasks for master context"
     }
   }

--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -767,7 +767,7 @@
               "5.5"
             ],
             "details": "- clamd: connect via TCP or Unix socket; timeouts 10s connect / 60s scan; stream-scan from MinIO (avoid local disk) using chunk bridge.\n- Scan policy: execute only for configured types (e.g., non-G-code CAD and videos) or if scan_enabled; on detection: delete object, 422 MALWARE_DETECTED with remediation hint.\n- Failure mode: fail closed if scan_enabled=true and clamd unreachable → 503 SCAN_UNAVAILABLE; log security_event.\n- Rate limiting: cap concurrent scans to protect resources.\n- Acceptance tests:\n  - EICAR string upload triggers 422 MALWARE_DETECTED and object removed.\n  - clamd down → finalize returns 503 SCAN_UNAVAILABLE when scan_enabled.\n  - scan_enabled=false → finalize succeeds without scan.",
-            "status": "in-progress",
+            "status": "done",
             "testStrategy": ""
           },
           {
@@ -1708,7 +1708,7 @@
     ],
     "metadata": {
       "created": "2025-08-15T19:56:57.780Z",
-      "updated": "2025-08-21T10:16:11.898Z",
+      "updated": "2025-08-21T10:27:24.713Z",
       "description": "Tasks for master context"
     }
   }

--- a/apps/api/CLAMAV_INTEGRATION.md
+++ b/apps/api/CLAMAV_INTEGRATION.md
@@ -1,0 +1,321 @@
+# ClamAV Integration - Task 5.6
+
+## Overview
+
+This document describes the ClamAV malware scanning integration implemented for Task 5.6. The integration provides enterprise-grade malware protection for file uploads with streaming scan capabilities, comprehensive error handling, and security event logging.
+
+## Features
+
+- **Streaming Scan**: Scans files directly from MinIO without storing to disk
+- **TCP/Unix Socket Support**: Connects to ClamAV daemon via TCP or Unix socket
+- **Configurable Policies**: Scan only specific file types (non-G-code CAD and videos)
+- **Rate Limiting**: Protects resources with concurrent scan limits
+- **Fail-Closed Security**: Blocks uploads if scanning is enabled but daemon unreachable
+- **Comprehensive Logging**: Security event logging and audit trails
+- **Turkish Localization**: Error messages in Turkish and English
+
+## Architecture
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│   File Service  │───▶│  ClamAV Service │───▶│   ClamAV Daemon │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+         │                       │                       │
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│      MinIO      │    │ Security Events │    │  Virus Database │
+│   (Streaming)   │    │   & Audit Log   │    │   (Updated)     │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+```
+
+## Configuration
+
+### Environment Variables
+
+Add these variables to your `.env` file:
+
+```bash
+# ClamAV Configuration
+CLAMAV_ENABLED=true
+CLAMAV_HOST=clamd
+CLAMAV_PORT=3310
+CLAMAV_TIMEOUT_CONNECT=10.0
+CLAMAV_TIMEOUT_SCAN=60.0
+CLAMAV_MAX_CONCURRENT_SCANS=3
+CLAMAV_SCAN_ENABLED=true
+```
+
+### Docker Compose
+
+The integration includes a ClamAV daemon service:
+
+```yaml
+clamd:
+  build:
+    context: ../../infra/docker/clamav
+  image: clamav-daemon:dev
+  container_name: fc_clamd_dev
+  command: ["clamd", "--foreground=yes", "--config-file=/etc/clamav/clamd.conf"]
+  ports:
+    - "3310:3310"
+  networks:
+    - freecad_network
+```
+
+## Usage
+
+### Starting Services
+
+1. Start with security profile:
+```bash
+docker compose -f infra/compose/docker-compose.dev.yml --profile security up -d
+```
+
+2. Verify ClamAV daemon is running:
+```bash
+docker logs fc_clamd_dev
+```
+
+### File Upload Process
+
+The ClamAV integration is automatically triggered during file upload finalization:
+
+1. **Upload Initialization**: Client gets presigned URL
+2. **File Upload**: Client uploads file to MinIO
+3. **Upload Finalization**: 
+   - SHA256 verification
+   - **ClamAV scanning** (Task 5.6)
+   - File metadata creation
+
+### Scanning Policies
+
+Files are scanned based on type and extension:
+
+**Scanned File Types:**
+- CAD models (`model/*`, `application/sla`, etc.)
+- Archives (`application/zip`, `application/gzip`, etc.)
+- Executables (`application/x-executable`, etc.)
+- Images and videos (can contain embedded malware)
+
+**Skipped File Types:**
+- G-code files (`.gcode`, `.nc`, `.txt`)
+- Configuration files (`.json`, `.xml`, `.csv`)
+- Log files (`.log`)
+
+## Error Handling
+
+### Malware Detection
+
+When malware is detected:
+
+```json
+{
+  "code": "MALWARE_DETECTED",
+  "message": "Malware detected and removed: Eicar-Test-Signature. Please ensure your file is clean and try again.",
+  "turkish_message": "Kötü amaçlı yazılım tespit edildi ve kaldırıldı: Eicar-Test-Signature. Lütfen dosyanızın temiz olduğundan emin olun ve tekrar deneyin.",
+  "status_code": 422,
+  "details": {
+    "virus_name": "Eicar-Test-Signature",
+    "scan_time_ms": 150.0,
+    "remediation": "Scan your file with updated antivirus software before re-uploading"
+  }
+}
+```
+
+### Daemon Unavailable
+
+When scanning is enabled but daemon is unreachable:
+
+```json
+{
+  "code": "STORAGE_ERROR", 
+  "message": "Malware scanning unavailable",
+  "turkish_message": "Kötü amaçlı yazılım taraması kullanılamıyor",
+  "status_code": 503
+}
+```
+
+### Scan Timeout
+
+When scan takes too long:
+
+```json
+{
+  "code": "STORAGE_ERROR",
+  "message": "Malware scan failed: Scan timeout after 60s", 
+  "status_code": 408
+}
+```
+
+## Security Features
+
+### Rate Limiting
+
+Concurrent scans are limited to protect system resources:
+
+```python
+CLAMAV_MAX_CONCURRENT_SCANS=3  # Maximum concurrent scans
+```
+
+### Security Event Logging
+
+All security events are logged to database and structured logs:
+
+```python
+SecurityEvent(
+    event_type=SecurityEventType.MALWARE_DETECTED,
+    description="Malware detected in uploaded file: Eicar-Test-Signature",
+    severity=SeverityLevel.CRITICAL,
+    details={
+        "object_key": "temp/job123/infected.exe",
+        "virus_name": "Eicar-Test-Signature",
+        "scan_time_ms": 150.0
+    }
+)
+```
+
+### Audit Trail
+
+All file deletions due to malware detection are logged via SHA256 service:
+
+```python
+sha256_service.delete_object_with_audit(
+    bucket_name="temp",
+    object_name="job123/infected.exe",
+    reason="Malware detected: Eicar-Test-Signature",
+    details={
+        "virus_name": "Eicar-Test-Signature",
+        "upload_id": "upload-123",
+        "scan_metadata": {...}
+    }
+)
+```
+
+## Testing
+
+### EICAR Test
+
+To test malware detection, upload the EICAR test string:
+
+```
+X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
+```
+
+This should trigger a `422 MALWARE_DETECTED` response.
+
+### Unit Tests
+
+Run the comprehensive test suite:
+
+```bash
+# ClamAV service tests
+pytest apps/api/tests/test_clamav_service.py -v
+
+# File service integration tests  
+pytest apps/api/tests/test_clamav_file_service_integration.py -v
+```
+
+### Manual Testing
+
+1. **Test daemon connectivity:**
+```bash
+docker exec fc_clamd_dev clamdscan --version
+```
+
+2. **Test EICAR detection:**
+```bash
+echo 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' > /tmp/eicar.txt
+docker exec fc_clamd_dev clamdscan /tmp/eicar.txt
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**1. ClamAV daemon not starting:**
+```bash
+# Check daemon logs
+docker logs fc_clamd_dev
+
+# Verify virus database
+docker exec fc_clamd_dev ls -la /var/lib/clamav/
+```
+
+**2. Connection refused errors:**
+```bash
+# Verify daemon is listening
+docker exec fc_clamd_dev netstat -tlnp | grep 3310
+
+# Check firewall/networking
+docker exec fc_clamd_dev ping clamd
+```
+
+**3. Scan timeouts:**
+```bash
+# Increase timeout in environment
+CLAMAV_TIMEOUT_SCAN=120.0
+
+# Check daemon performance
+docker stats fc_clamd_dev
+```
+
+**4. False positives:**
+```bash
+# Check virus database version
+docker exec fc_clamd_dev freshclam --version
+
+# Update virus database
+docker exec fc_clamd_dev freshclam --no-warnings
+```
+
+### Performance Tuning
+
+**Memory Usage:**
+- ClamAV daemon uses ~1-2GB RAM
+- Increase memory limits for large file scanning
+
+**CPU Usage:**
+- Limit concurrent scans: `CLAMAV_MAX_CONCURRENT_SCANS=2`
+- Adjust daemon threads in clamd.conf: `MaxThreads=6`
+
+**Network Timeouts:**
+- Connection: `CLAMAV_TIMEOUT_CONNECT=15.0`
+- Scan: `CLAMAV_TIMEOUT_SCAN=90.0`
+
+## Production Deployment
+
+### Security Hardening
+
+1. **Use Unix sockets** instead of TCP when possible
+2. **Enable all scan types** in clamd.conf
+3. **Regular database updates** via freshclam
+4. **Monitor security events** and set up alerts
+5. **Log rotation** for ClamAV logs
+
+### High Availability
+
+1. **Multiple ClamAV instances** behind load balancer
+2. **Health checks** and automatic restart
+3. **Shared virus database** storage
+4. **Monitoring and alerting** integration
+
+### Compliance
+
+- **Audit logging** for regulatory compliance
+- **Data retention** policies for security events  
+- **Incident response** procedures for malware detection
+- **Regular security** assessments and penetration testing
+
+## API Documentation
+
+The ClamAV integration is transparent to API clients. Malware scanning occurs automatically during upload finalization with appropriate error responses for detection scenarios.
+
+## Support
+
+For issues or questions regarding ClamAV integration:
+
+1. Check logs: `docker logs fc_clamd_dev`
+2. Run tests: `pytest apps/api/tests/test_clamav*.py -v`
+3. Verify configuration: Review environment variables
+4. Monitor security events: Check database security_events table

--- a/apps/api/app/core/environment.py
+++ b/apps/api/app/core/environment.py
@@ -335,6 +335,50 @@ class UltraEnterpriseEnvironment(BaseSettings):
     S3_BUCKET_NAME: str = Field(default="dev-artifacts", description="S3 bucket name")
     
     # ===================================================================
+    # CLAMAV MALWARE SCANNING - TASK 5.6
+    # ===================================================================
+    
+    CLAMAV_ENABLED: bool = Field(
+        default=True,
+        description="Enable ClamAV malware scanning for uploaded files"
+    )
+    
+    CLAMAV_HOST: str = Field(
+        default="clamd",
+        description="ClamAV daemon hostname (Docker service name)"
+    )
+    
+    CLAMAV_PORT: int = Field(
+        default=3310,
+        description="ClamAV daemon TCP port"
+    )
+    
+    CLAMAV_UNIX_SOCKET: Optional[str] = Field(
+        default=None,
+        description="ClamAV Unix socket path (preferred over TCP)"
+    )
+    
+    CLAMAV_TIMEOUT_CONNECT: float = Field(
+        default=10.0,
+        description="ClamAV connection timeout in seconds"
+    )
+    
+    CLAMAV_TIMEOUT_SCAN: float = Field(
+        default=60.0,
+        description="ClamAV scan timeout in seconds"
+    )
+    
+    CLAMAV_MAX_CONCURRENT_SCANS: int = Field(
+        default=3,
+        description="Maximum concurrent ClamAV scans to protect resources"
+    )
+    
+    CLAMAV_SCAN_ENABLED: bool = Field(
+        default=True,
+        description="Whether ClamAV scanning is enabled (fail closed if true and daemon unreachable)"
+    )
+    
+    # ===================================================================
     # FREECAD & APPLICATION SPECIFIC
     # ===================================================================
     

--- a/apps/api/app/core/environment.py
+++ b/apps/api/app/core/environment.py
@@ -373,9 +373,9 @@ class UltraEnterpriseEnvironment(BaseSettings):
         description="Maximum concurrent ClamAV scans to protect resources"
     )
     
-    CLAMAV_SCAN_ENABLED: bool = Field(
+    CLAMAV_FAIL_CLOSED: bool = Field(
         default=True,
-        description="Whether ClamAV scanning is enabled (fail closed if true and daemon unreachable)"
+        description="Fail-closed security policy: block uploads if ClamAV daemon is unreachable"
     )
     
     # ===================================================================

--- a/apps/api/app/services/clamav_service.py
+++ b/apps/api/app/services/clamav_service.py
@@ -1,0 +1,856 @@
+"""
+Ultra-Enterprise ClamAV Service for Task 5.6
+
+Implements malware scanning for uploaded files with:
+- ClamAV daemon integration via TCP/Unix sockets
+- Streaming scan from MinIO without disk storage
+- Robust error handling and rate limiting
+- Security event logging and audit trail
+- Configurable file type scanning policies
+- Enterprise-grade timeouts and failure modes
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from io import BytesIO
+from typing import Any, Dict, List, Optional, Union
+
+import clamd
+import structlog
+from minio import Minio
+from minio.error import S3Error
+from sqlalchemy.orm import Session
+
+from app.models.security_event import SecurityEvent, SecurityEventType, SeverityLevel
+from app.schemas.file_upload import UploadErrorCode
+
+logger = structlog.get_logger(__name__)
+
+# EICAR test string for testing purposes
+EICAR_TEST_STRING = (
+    "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+)
+
+# File types that should be scanned (non-G-code CAD and videos)
+SCANNABLE_FILE_TYPES = {
+    "model",  # CAD files
+    "temp",   # Temporary uploads
+    "report", # Reports might contain embedded content
+}
+
+# MIME types that require scanning
+SCANNABLE_MIME_TYPES = {
+    # CAD/3D model formats
+    "application/sla",
+    "application/step", 
+    "model/iges",
+    "model/obj",
+    "application/x-3ds",
+    "application/x-blend",
+    "application/x-freecad",
+    # Archive formats that might contain malware
+    "application/zip",
+    "application/x-zip-compressed",
+    "application/gzip",
+    "application/x-gzip",
+    "application/x-tar",
+    "application/x-7z-compressed",
+    # Document formats
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    # Image formats (can contain embedded malware)
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/bmp",
+    "image/tiff",
+    # Video formats
+    "video/mp4",
+    "video/avi", 
+    "video/mkv",
+    "video/webm",
+    # Executable formats (high risk)
+    "application/x-executable",
+    "application/x-msdownload",
+    "application/x-msdos-program",
+}
+
+# File extensions to skip scanning (G-code and safe text files)
+SKIP_SCAN_EXTENSIONS = {
+    ".nc",    # G-code
+    ".gcode", # G-code
+    ".txt",   # Plain text G-code
+    ".json",  # JSON configuration
+    ".xml",   # XML configuration
+    ".csv",   # CSV data
+    ".log",   # Log files
+}
+
+
+class ClamAVError(Exception):
+    """Base exception for ClamAV service operations."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        turkish_message: str | None = None,
+        details: dict | None = None,
+        status_code: int = 500,
+    ):
+        self.code = code
+        self.message = message
+        self.turkish_message = turkish_message or message
+        self.details = details or {}
+        self.status_code = status_code
+        super().__init__(self.message)
+
+
+class ClamAVScanResult:
+    """Result of a ClamAV scan operation."""
+
+    def __init__(
+        self,
+        is_clean: bool,
+        scan_time_ms: float,
+        virus_name: str | None = None,
+        scan_metadata: dict | None = None,
+        error_message: str | None = None,
+    ):
+        self.is_clean = is_clean
+        self.scan_time_ms = scan_time_ms
+        self.virus_name = virus_name
+        self.scan_metadata = scan_metadata or {}
+        self.error_message = error_message
+
+    def __repr__(self) -> str:
+        status = "CLEAN" if self.is_clean else f"INFECTED({self.virus_name})"
+        return f"ClamAVScanResult(status={status}, time={self.scan_time_ms:.2f}ms)"
+
+
+class ClamAVRateLimiter:
+    """Rate limiter for concurrent ClamAV scans."""
+
+    def __init__(self, max_concurrent_scans: int = 3):
+        self._semaphore = asyncio.Semaphore(max_concurrent_scans)
+        self._active_scans = 0
+        self._total_scans = 0
+        self._lock = threading.Lock()
+
+    @asynccontextmanager
+    async def acquire_scan_slot(self):
+        """Acquire a scan slot with rate limiting."""
+        try:
+            # Wait for available slot
+            async with self._semaphore:
+                with self._lock:
+                    self._active_scans += 1
+                    self._total_scans += 1
+                
+                logger.info(
+                    "ClamAV scan slot acquired",
+                    active_scans=self._active_scans,
+                    total_scans=self._total_scans,
+                )
+                
+                yield
+        finally:
+            with self._lock:
+                self._active_scans -= 1
+            
+            logger.info(
+                "ClamAV scan slot released",
+                active_scans=self._active_scans,
+                total_scans=self._total_scans,
+            )
+
+    def get_stats(self) -> dict:
+        """Get current rate limiter statistics."""
+        with self._lock:
+            return {
+                "active_scans": self._active_scans,
+                "total_scans": self._total_scans,
+                "available_slots": self._semaphore._value,
+            }
+
+
+class ClamAVService:
+    """
+    Ultra-Enterprise ClamAV service for Task 5.6.
+    
+    Features:
+    - TCP and Unix socket connections to clamd
+    - Streaming scan from MinIO objects
+    - Rate limiting for resource protection  
+    - Comprehensive error handling and audit logging
+    - Security event tracking
+    - Configurable scanning policies
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 3310,
+        unix_socket: str | None = None,
+        timeout_connect: float = 10.0,
+        timeout_scan: float = 60.0,
+        max_concurrent_scans: int = 3,
+        scan_enabled: bool = True,
+        db: Session | None = None,
+        minio_client: Minio | None = None,
+    ):
+        """
+        Initialize ClamAV service.
+        
+        Args:
+            host: ClamAV daemon host (default: localhost)
+            port: ClamAV daemon port (default: 3310) 
+            unix_socket: Unix socket path (preferred over TCP)
+            timeout_connect: Connection timeout in seconds
+            timeout_scan: Scan timeout in seconds
+            max_concurrent_scans: Maximum concurrent scans
+            scan_enabled: Whether scanning is enabled
+            db: Database session for audit logging
+            minio_client: MinIO client for streaming
+        """
+        self.host = host
+        self.port = port  
+        self.unix_socket = unix_socket
+        self.timeout_connect = timeout_connect
+        self.timeout_scan = timeout_scan
+        self.scan_enabled = scan_enabled
+        self.db = db
+        self.minio_client = minio_client
+        
+        # Initialize rate limiter
+        self.rate_limiter = ClamAVRateLimiter(max_concurrent_scans)
+        
+        # Connection instance (lazy initialized)
+        self._clamd_client: clamd.ClamdNetworkSocket | clamd.ClamdUnixSocket | None = None
+        
+        logger.info(
+            "ClamAV service initialized",
+            host=self.host,
+            port=self.port,
+            unix_socket=self.unix_socket,
+            timeout_connect=self.timeout_connect,
+            timeout_scan=self.timeout_scan,
+            scan_enabled=self.scan_enabled,
+            max_concurrent_scans=max_concurrent_scans,
+        )
+
+    def _get_clamd_client(self) -> clamd.ClamdNetworkSocket | clamd.ClamdUnixSocket:
+        """Get ClamAV daemon client with connection priority: Unix socket > TCP."""
+        if self._clamd_client is None:
+            if self.unix_socket:
+                # Prefer Unix socket connection
+                logger.debug(
+                    "Initializing ClamAV Unix socket connection",
+                    unix_socket=self.unix_socket,
+                )
+                self._clamd_client = clamd.ClamdUnixSocket(
+                    path=self.unix_socket,
+                    timeout=self.timeout_connect,
+                )
+            else:
+                # Fallback to TCP connection
+                logger.debug(
+                    "Initializing ClamAV TCP connection",
+                    host=self.host,
+                    port=self.port,
+                )
+                self._clamd_client = clamd.ClamdNetworkSocket(
+                    host=self.host,
+                    port=self.port,
+                    timeout=self.timeout_connect,
+                )
+        
+        return self._clamd_client
+
+    def _log_security_event(
+        self,
+        event_type: SecurityEventType,
+        description: str,
+        details: dict | None = None,
+        severity: SeverityLevel = SeverityLevel.HIGH,
+    ) -> None:
+        """Log security event to database and structured logs."""
+        try:
+            # Structured logging (always happens)
+            logger.warning(
+                "ClamAV security event",
+                event_type=event_type.value,
+                description=description,
+                details=details or {},
+                severity=severity.value,
+            )
+
+            # Database logging (if available)
+            if self.db:
+                security_event = SecurityEvent(
+                    event_type=event_type,
+                    description=description,
+                    details=details or {},
+                    severity=severity,
+                    source_ip="system",  # Internal scan
+                    user_agent="ClamAV-Service/1.0",
+                    occurred_at=datetime.now(UTC),
+                )
+                self.db.add(security_event)
+                self.db.commit()
+
+        except Exception as e:
+            logger.error(
+                "Failed to log ClamAV security event",
+                error=str(e),
+                event_type=event_type.value if event_type else None,
+                description=description,
+            )
+
+    def ping(self) -> bool:
+        """
+        Test connection to ClamAV daemon.
+        
+        Returns:
+            bool: True if daemon is reachable, False otherwise
+        """
+        try:
+            client = self._get_clamd_client()
+            response = client.ping()
+            is_alive = response == "PONG"
+            
+            logger.info(
+                "ClamAV daemon ping result",
+                is_alive=is_alive,
+                response=response,
+            )
+            
+            return is_alive
+        except Exception as e:
+            logger.error(
+                "ClamAV daemon ping failed",
+                error=str(e),
+                host=self.host,
+                port=self.port,
+                unix_socket=self.unix_socket,
+            )
+            return False
+
+    def get_version(self) -> str | None:
+        """
+        Get ClamAV daemon version.
+        
+        Returns:
+            str | None: Version string or None if unavailable
+        """
+        try:
+            client = self._get_clamd_client()
+            version = client.version()
+            
+            logger.info("ClamAV daemon version", version=version)
+            return version
+            
+        except Exception as e:
+            logger.error("Failed to get ClamAV version", error=str(e))
+            return None
+
+    def _should_scan_file(
+        self,
+        object_key: str,
+        mime_type: str | None = None,
+        file_type: str | None = None,
+    ) -> bool:
+        """
+        Determine if file should be scanned based on policies.
+        
+        Args:
+            object_key: S3 object key
+            mime_type: MIME type of the file
+            file_type: File type enum value
+            
+        Returns:
+            bool: True if file should be scanned
+        """
+        if not self.scan_enabled:
+            return False
+
+        # Extract file extension
+        if "." in object_key:
+            extension = "." + object_key.rsplit(".", 1)[-1].lower()
+            if extension in SKIP_SCAN_EXTENSIONS:
+                logger.debug(
+                    "Skipping scan for safe file extension",
+                    object_key=object_key,
+                    extension=extension,
+                )
+                return False
+
+        # Check file type
+        if file_type and file_type not in SCANNABLE_FILE_TYPES:
+            logger.debug(
+                "Skipping scan for file type",
+                object_key=object_key,
+                file_type=file_type,
+            )
+            return False
+
+        # Check MIME type
+        if mime_type and mime_type not in SCANNABLE_MIME_TYPES:
+            logger.debug(
+                "Skipping scan for MIME type",
+                object_key=object_key,
+                mime_type=mime_type,
+            )
+            return False
+
+        return True
+
+    async def scan_object_stream(
+        self,
+        bucket_name: str,
+        object_name: str,
+        mime_type: str | None = None,
+        file_type: str | None = None,
+        max_size_bytes: int = 100 * 1024 * 1024,  # 100MB default limit
+    ) -> ClamAVScanResult:
+        """
+        Stream scan an S3 object using ClamAV without storing to disk.
+        
+        Args:
+            bucket_name: S3 bucket name
+            object_name: S3 object name  
+            mime_type: MIME type for policy decisions
+            file_type: File type for policy decisions
+            max_size_bytes: Maximum file size to scan
+            
+        Returns:
+            ClamAVScanResult: Scan result with metadata
+            
+        Raises:
+            ClamAVError: On scan failure or daemon unavailable
+        """
+        object_key = f"{bucket_name}/{object_name}"
+        
+        # Check scan policy
+        if not self._should_scan_file(object_key, mime_type, file_type):
+            logger.debug(
+                "File scan skipped by policy",
+                object_key=object_key,
+                mime_type=mime_type,
+                file_type=file_type,
+            )
+            return ClamAVScanResult(
+                is_clean=True,
+                scan_time_ms=0.0,
+                scan_metadata={"scan_skipped": True, "reason": "policy"},
+            )
+
+        # Fail closed if scanning is enabled but daemon is unreachable
+        if self.scan_enabled and not self.ping():
+            self._log_security_event(
+                event_type=SecurityEventType.MALWARE_SCAN_FAILURE,
+                description="ClamAV daemon unavailable but scan_enabled=true",
+                details={
+                    "object_key": object_key,
+                    "host": self.host,
+                    "port": self.port,
+                    "unix_socket": self.unix_socket,
+                },
+                severity=SeverityLevel.HIGH,
+            )
+            raise ClamAVError(
+                code="SCAN_UNAVAILABLE",
+                message="Malware scanning unavailable",
+                turkish_message="Kötü amaçlı yazılım taraması kullanılamıyor",
+                details={
+                    "object_key": object_key,
+                    "daemon_status": "unreachable",
+                },
+                status_code=503,
+            )
+
+        # Rate limiting
+        async with self.rate_limiter.acquire_scan_slot():
+            start_time = datetime.now(UTC)
+            
+            try:
+                if not self.minio_client:
+                    raise ClamAVError(
+                        code="MINIO_CLIENT_UNAVAILABLE",
+                        message="MinIO client not available for streaming",
+                        turkish_message="MinIO istemcisi mevcut değil",
+                        status_code=500,
+                    )
+
+                # Check object size before streaming
+                try:
+                    stat = self.minio_client.stat_object(bucket_name, object_name)
+                    if stat.size > max_size_bytes:
+                        logger.warning(
+                            "Object too large for ClamAV scanning",
+                            object_key=object_key,
+                            size=stat.size,
+                            max_size=max_size_bytes,
+                        )
+                        return ClamAVScanResult(
+                            is_clean=True,  # Assume clean for oversized files
+                            scan_time_ms=0.0,
+                            scan_metadata={
+                                "scan_skipped": True,
+                                "reason": "oversized",
+                                "size": stat.size,
+                                "max_size": max_size_bytes,
+                            },
+                        )
+                except S3Error as e:
+                    raise ClamAVError(
+                        code="OBJECT_NOT_FOUND",
+                        message=f"Object not found for scanning: {object_key}",
+                        turkish_message=f"Taranacak nesne bulunamadı: {object_key}",
+                        details={"s3_error": str(e)},
+                        status_code=404,
+                    )
+
+                # Stream object from MinIO in chunks to avoid memory issues
+                logger.info(
+                    "Starting ClamAV streaming scan",
+                    object_key=object_key,
+                    size=stat.size,
+                    mime_type=mime_type,
+                )
+
+                # Create BytesIO buffer for streaming
+                buffer = BytesIO()
+                
+                try:
+                    # Stream object from MinIO
+                    response = self.minio_client.get_object(bucket_name, object_name)
+                    
+                    # Read in chunks to avoid memory exhaustion
+                    chunk_size = 8 * 1024 * 1024  # 8MB chunks
+                    total_bytes = 0
+                    
+                    for chunk in response.stream(chunk_size):
+                        if not chunk:
+                            break
+                        buffer.write(chunk)
+                        total_bytes += len(chunk)
+                        
+                        # Safety check to prevent runaway memory usage
+                        if total_bytes > max_size_bytes:
+                            break
+                    
+                    # Reset buffer position for scanning
+                    buffer.seek(0)
+                    
+                finally:
+                    response.close()
+                    response.release_conn()
+
+                # Perform ClamAV scan using instream
+                client = self._get_clamd_client()
+                scan_start_time = datetime.now(UTC)
+                
+                try:
+                    # Set scan-specific timeout
+                    client.timeout = self.timeout_scan
+                    
+                    # Perform streaming scan
+                    scan_result = client.instream(buffer)
+                    
+                    scan_end_time = datetime.now(UTC)
+                    scan_time_ms = (scan_end_time - scan_start_time).total_seconds() * 1000
+                    
+                    # Parse scan result
+                    # Result format: {'stream': ('FOUND', 'Virus-Name')} or {'stream': ('OK', None)}
+                    stream_result = scan_result.get("stream")
+                    if not stream_result:
+                        raise ClamAVError(
+                            code="SCAN_RESULT_INVALID",
+                            message="Invalid scan result format",
+                            turkish_message="Geçersiz tarama sonucu formatı",
+                            status_code=500,
+                        )
+                    
+                    status, virus_name = stream_result
+                    is_clean = status == "OK"
+                    
+                    # Log scan result
+                    logger.info(
+                        "ClamAV scan completed",
+                        object_key=object_key,
+                        is_clean=is_clean,
+                        virus_name=virus_name,
+                        scan_time_ms=scan_time_ms,
+                        bytes_scanned=total_bytes,
+                    )
+                    
+                    # Security event for malware detection
+                    if not is_clean:
+                        self._log_security_event(
+                            event_type=SecurityEventType.MALWARE_DETECTED,
+                            description=f"Malware detected in uploaded file: {virus_name}",
+                            details={
+                                "object_key": object_key,
+                                "virus_name": virus_name,
+                                "scan_time_ms": scan_time_ms,
+                                "file_size": total_bytes,
+                                "mime_type": mime_type,
+                            },
+                            severity=SeverityLevel.CRITICAL,
+                        )
+                    
+                    return ClamAVScanResult(
+                        is_clean=is_clean,
+                        scan_time_ms=scan_time_ms,
+                        virus_name=virus_name if not is_clean else None,
+                        scan_metadata={
+                            "bytes_scanned": total_bytes,
+                            "object_size": stat.size,
+                            "mime_type": mime_type,
+                            "file_type": file_type,
+                            "scan_method": "instream",
+                        },
+                    )
+                    
+                except socket.timeout:
+                    scan_time_ms = (datetime.now(UTC) - scan_start_time).total_seconds() * 1000
+                    self._log_security_event(
+                        event_type=SecurityEventType.MALWARE_SCAN_FAILURE,
+                        description=f"ClamAV scan timeout after {scan_time_ms:.0f}ms",
+                        details={
+                            "object_key": object_key,
+                            "timeout_ms": self.timeout_scan * 1000,
+                            "scan_time_ms": scan_time_ms,
+                        },
+                        severity=SeverityLevel.MEDIUM,
+                    )
+                    raise ClamAVError(
+                        code="SCAN_TIMEOUT",
+                        message=f"Scan timeout after {self.timeout_scan}s",
+                        turkish_message=f"{self.timeout_scan}s sonra tarama zaman aşımı",
+                        details={"timeout_seconds": self.timeout_scan},
+                        status_code=408,
+                    )
+                    
+                except clamd.ConnectionError as e:
+                    self._log_security_event(
+                        event_type=SecurityEventType.MALWARE_SCAN_FAILURE,
+                        description=f"ClamAV connection error: {str(e)}",
+                        details={
+                            "object_key": object_key,
+                            "connection_error": str(e),
+                            "host": self.host,
+                            "port": self.port,
+                        },
+                        severity=SeverityLevel.HIGH,
+                    )
+                    raise ClamAVError(
+                        code="CLAMD_CONNECTION_ERROR",
+                        message=f"ClamAV daemon connection failed: {str(e)}",
+                        turkish_message=f"ClamAV daemon bağlantısı başarısız: {str(e)}",
+                        details={"connection_error": str(e)},
+                        status_code=503,
+                    )
+                    
+                except Exception as e:
+                    scan_time_ms = (datetime.now(UTC) - scan_start_time).total_seconds() * 1000
+                    self._log_security_event(
+                        event_type=SecurityEventType.MALWARE_SCAN_FAILURE,
+                        description=f"ClamAV scan error: {str(e)}",
+                        details={
+                            "object_key": object_key,
+                            "error": str(e),
+                            "error_type": type(e).__name__,
+                            "scan_time_ms": scan_time_ms,
+                        },
+                        severity=SeverityLevel.HIGH,
+                    )
+                    raise ClamAVError(
+                        code="SCAN_ERROR",
+                        message=f"Scan failed: {str(e)}",
+                        turkish_message=f"Tarama başarısız: {str(e)}",
+                        details={"error": str(e)},
+                        status_code=500,
+                    )
+
+            except ClamAVError:
+                raise
+            except Exception as e:
+                total_time_ms = (datetime.now(UTC) - start_time).total_seconds() * 1000
+                logger.error(
+                    "Unexpected error during ClamAV scan",
+                    object_key=object_key,
+                    error=str(e),
+                    total_time_ms=total_time_ms,
+                    exc_info=True,
+                )
+                raise ClamAVError(
+                    code="UNEXPECTED_SCAN_ERROR",
+                    message=f"Unexpected scan error: {str(e)}",
+                    turkish_message=f"Beklenmeyen tarama hatası: {str(e)}",
+                    details={"error": str(e)},
+                    status_code=500,
+                )
+
+    def scan_eicar_test(self) -> ClamAVScanResult:
+        """
+        Test ClamAV functionality using EICAR test string.
+        
+        Returns:
+            ClamAVScanResult: Should detect EICAR test signature
+            
+        Raises:
+            ClamAVError: On scan failure
+        """
+        logger.info("Running ClamAV EICAR test")
+        
+        try:
+            client = self._get_clamd_client()
+            buffer = BytesIO(EICAR_TEST_STRING.encode())
+            
+            start_time = datetime.now(UTC)
+            result = client.instream(buffer)
+            end_time = datetime.now(UTC)
+            
+            scan_time_ms = (end_time - start_time).total_seconds() * 1000
+            
+            stream_result = result.get("stream")
+            if not stream_result:
+                raise ClamAVError(
+                    code="EICAR_TEST_FAILED",
+                    message="EICAR test failed - no scan result",
+                    turkish_message="EICAR testi başarısız - tarama sonucu yok",
+                    status_code=500,
+                )
+            
+            status, virus_name = stream_result
+            is_clean = status == "OK"
+            expected_virus = "Eicar-Test-Signature"
+            
+            # EICAR should be detected as infected
+            if is_clean:
+                logger.error("EICAR test failed - should be detected as infected")
+                raise ClamAVError(
+                    code="EICAR_NOT_DETECTED",
+                    message="EICAR test string was not detected - ClamAV may be misconfigured",
+                    turkish_message="EICAR test dizesi tespit edilmedi - ClamAV yanlış yapılandırılmış olabilir",
+                    status_code=500,
+                )
+            
+            logger.info(
+                "EICAR test successful",
+                virus_name=virus_name,
+                scan_time_ms=scan_time_ms,
+                expected_virus=expected_virus,
+            )
+            
+            return ClamAVScanResult(
+                is_clean=False,
+                scan_time_ms=scan_time_ms,
+                virus_name=virus_name,
+                scan_metadata={
+                    "test_type": "eicar",
+                    "expected_virus": expected_virus,
+                    "test_passed": virus_name == expected_virus,
+                },
+            )
+            
+        except ClamAVError:
+            raise
+        except Exception as e:
+            logger.error("EICAR test failed with exception", error=str(e), exc_info=True)
+            raise ClamAVError(
+                code="EICAR_TEST_ERROR",
+                message=f"EICAR test error: {str(e)}",
+                turkish_message=f"EICAR test hatası: {str(e)}",
+                details={"error": str(e)},
+                status_code=500,
+            )
+
+    def get_stats(self) -> dict:
+        """Get ClamAV service statistics."""
+        daemon_stats = {
+            "daemon_reachable": self.ping(),
+            "daemon_version": self.get_version(),
+        }
+        
+        rate_limiter_stats = self.rate_limiter.get_stats()
+        
+        return {
+            "scan_enabled": self.scan_enabled,
+            "connection": {
+                "host": self.host,
+                "port": self.port,
+                "unix_socket": self.unix_socket,
+                "timeout_connect": self.timeout_connect,
+                "timeout_scan": self.timeout_scan,
+            },
+            "daemon": daemon_stats,
+            "rate_limiter": rate_limiter_stats,
+            "scannable_types": list(SCANNABLE_FILE_TYPES),
+            "skip_extensions": list(SKIP_SCAN_EXTENSIONS),
+        }
+
+
+def get_clamav_service(
+    host: str | None = None,
+    port: int | None = None,
+    unix_socket: str | None = None,
+    timeout_connect: float | None = None,
+    timeout_scan: float | None = None,
+    max_concurrent_scans: int | None = None,
+    scan_enabled: bool | None = None,
+    db: Session | None = None,
+    minio_client: Minio | None = None,
+) -> ClamAVService:
+    """
+    Get ClamAV service instance for dependency injection with environment configuration.
+    
+    Args:
+        host: ClamAV daemon host (overrides env var)
+        port: ClamAV daemon port (overrides env var)
+        unix_socket: Unix socket path (overrides env var)
+        timeout_connect: Connection timeout (overrides env var)
+        timeout_scan: Scan timeout (overrides env var)
+        max_concurrent_scans: Max concurrent scans (overrides env var)
+        scan_enabled: Whether scanning is enabled (overrides env var)
+        db: Database session
+        minio_client: MinIO client for streaming
+        
+    Returns:
+        ClamAVService: Configured service instance
+    """
+    # Import environment configuration
+    from app.core.environment import environment
+    
+    # Use environment variables as defaults, allow parameter overrides
+    return ClamAVService(
+        host=host or environment.CLAMAV_HOST,
+        port=port or environment.CLAMAV_PORT,
+        unix_socket=unix_socket or environment.CLAMAV_UNIX_SOCKET,
+        timeout_connect=timeout_connect or environment.CLAMAV_TIMEOUT_CONNECT,
+        timeout_scan=timeout_scan or environment.CLAMAV_TIMEOUT_SCAN,
+        max_concurrent_scans=max_concurrent_scans or environment.CLAMAV_MAX_CONCURRENT_SCANS,
+        scan_enabled=scan_enabled if scan_enabled is not None else environment.CLAMAV_SCAN_ENABLED,
+        db=db,
+        minio_client=minio_client,
+    )
+
+
+__all__ = [
+    "ClamAVService",
+    "ClamAVError", 
+    "ClamAVScanResult",
+    "get_clamav_service",
+    "EICAR_TEST_STRING",
+    "SCANNABLE_FILE_TYPES",
+    "SCANNABLE_MIME_TYPES",
+    "SKIP_SCAN_EXTENSIONS",
+]

--- a/apps/api/app/services/file_service.py
+++ b/apps/api/app/services/file_service.py
@@ -55,6 +55,11 @@ from app.services.sha256_service import (
     SHA256StreamingService,
     get_sha256_streaming_service,
 )
+from app.services.clamav_service import (
+    ClamAVError,
+    ClamAVService,
+    get_clamav_service,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -96,6 +101,7 @@ class FileService:
         db: Session | None = None,
         validation_service: FileValidationService | None = None,
         sha256_service: SHA256StreamingService | None = None,
+        clamav_service: ClamAVService | None = None,
     ):
         """
         Initialize file service.
@@ -106,6 +112,7 @@ class FileService:
             db: Database session
             validation_service: File validation service
             sha256_service: SHA256 streaming service
+            clamav_service: ClamAV malware scanning service
         """
         self.client = client or get_minio_client()
         self.config = config or get_minio_config()
@@ -113,8 +120,9 @@ class FileService:
         self.db = db
         self.validation_service = validation_service or get_file_validation_service()
         self.sha256_service = sha256_service or get_sha256_streaming_service(self.client)
+        self.clamav_service = clamav_service or get_clamav_service(db=db, minio_client=self.client)
 
-        logger.info("File service initialized with validation and SHA256 streaming")
+        logger.info("File service initialized with validation, SHA256 streaming, and ClamAV scanning")
 
     def init_upload(
         self,
@@ -697,7 +705,138 @@ class FileService:
                     status_code=500,
                 )
 
-            # Step 6: Create file metadata record
+            # Step 6: Task 5.6 - ClamAV malware scanning
+            # Scan file for malware using streaming from MinIO
+            logger.info(
+                "Starting ClamAV malware scan",
+                bucket=bucket_name,
+                object=object_name,
+                upload_id=request.upload_id,
+            )
+
+            try:
+                # Extract file type for ClamAV policy decisions
+                file_type_str = session.metadata.get("type", "temp")
+                
+                # Perform asynchronous malware scan
+                import asyncio
+                try:
+                    # Run the async scan in the current thread's event loop
+                    scan_result = asyncio.run(
+                        self.clamav_service.scan_object_stream(
+                            bucket_name=bucket_name,
+                            object_name=object_name,
+                            mime_type=session.mime_type,
+                            file_type=file_type_str,
+                            max_size_bytes=100 * 1024 * 1024,  # 100MB limit
+                        )
+                    )
+                except RuntimeError:
+                    # Handle case where event loop is already running
+                    loop = asyncio.get_event_loop()
+                    scan_result = loop.run_until_complete(
+                        self.clamav_service.scan_object_stream(
+                            bucket_name=bucket_name,
+                            object_name=object_name,
+                            mime_type=session.mime_type,
+                            file_type=file_type_str,
+                            max_size_bytes=100 * 1024 * 1024,
+                        )
+                    )
+
+                logger.info(
+                    "ClamAV scan completed",
+                    is_clean=scan_result.is_clean,
+                    scan_time_ms=scan_result.scan_time_ms,
+                    virus_name=scan_result.virus_name,
+                    object_key=request.key,
+                    scan_metadata=scan_result.scan_metadata,
+                )
+
+                # Handle malware detection - delete object immediately
+                if not scan_result.is_clean:
+                    # Delete the infected object with comprehensive audit logging
+                    self.sha256_service.delete_object_with_audit(
+                        bucket_name=bucket_name,
+                        object_name=object_name,
+                        reason=f"Malware detected: {scan_result.virus_name}",
+                        details={
+                            "virus_name": scan_result.virus_name,
+                            "scan_time_ms": scan_result.scan_time_ms,
+                            "upload_id": request.upload_id,
+                            "object_key": request.key,
+                            "scan_metadata": scan_result.scan_metadata,
+                        },
+                    )
+
+                    # Raise malware detection error with remediation hint
+                    raise FileServiceError(
+                        code="MALWARE_DETECTED",
+                        message=f"Malware detected and removed: {scan_result.virus_name}. "
+                                f"Please ensure your file is clean and try again. "
+                                f"If you believe this is a false positive, contact support.",
+                        turkish_message=f"Kötü amaçlı yazılım tespit edildi ve kaldırıldı: {scan_result.virus_name}. "
+                                       f"Lütfen dosyanızın temiz olduğundan emin olun ve tekrar deneyin. "
+                                       f"Bu yanlış pozitif olduğuna inanıyorsanız, destek ile iletişime geçin.",
+                        details={
+                            "virus_name": scan_result.virus_name,
+                            "scan_time_ms": scan_result.scan_time_ms,
+                            "remediation": "Scan your file with updated antivirus software before re-uploading",
+                            "remediation_tr": "Tekrar yüklemeden önce dosyanızı güncel antivirüs yazılımı ile tarayın",
+                        },
+                        status_code=422,
+                    )
+
+            except ClamAVError as e:
+                # Handle specific ClamAV errors
+                logger.error(
+                    "ClamAV scan failed",
+                    error=e.message,
+                    code=e.code,
+                    details=e.details,
+                    bucket=bucket_name,
+                    object=object_name,
+                    upload_id=request.upload_id,
+                )
+
+                # Map ClamAV errors to appropriate FileServiceError codes
+                if e.code == "SCAN_UNAVAILABLE":
+                    # Fail closed - scanning is required but unavailable
+                    raise FileServiceError(
+                        code=UploadErrorCode.STORAGE_ERROR,
+                        message=e.message,
+                        turkish_message=e.turkish_message,
+                        details=e.details,
+                        status_code=e.status_code,
+                    )
+                else:
+                    # Other scan errors (timeouts, connection issues)
+                    raise FileServiceError(
+                        code=UploadErrorCode.STORAGE_ERROR,
+                        message=f"Malware scan failed: {e.message}",
+                        turkish_message=f"Kötü amaçlı yazılım taraması başarısız: {e.turkish_message}",
+                        details=e.details,
+                        status_code=e.status_code,
+                    )
+
+            except FileServiceError:
+                raise
+            except Exception as e:
+                logger.error(
+                    "Unexpected error during ClamAV scan",
+                    error=str(e),
+                    bucket=bucket_name,
+                    object=object_name,
+                    exc_info=True,
+                )
+                raise FileServiceError(
+                    code=UploadErrorCode.STORAGE_ERROR,
+                    message=f"Failed to scan file for malware: {str(e)}",
+                    turkish_message=f"Dosya kötü amaçlı yazılım taraması başarısız: {str(e)}",
+                    status_code=500,
+                )
+
+            # Step 7: Create file metadata record
             if self.db:
                 file_metadata = FileMetadata(
                     object_key=request.key,
@@ -736,10 +875,10 @@ class FileService:
                     status=FileStatus.COMPLETED.value,
                 )
 
-            # Step 7: Get object metadata for response
+            # Step 8: Get object metadata for response
             metadata = self._get_object_metadata(bucket_name, object_name)
 
-            # Step 8: Build response
+            # Step 9: Build response
             response = UploadFinalizeResponse(
                 success=True,
                 object_key=request.key,

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -75,4 +75,6 @@ pydyf>=0.10.0
 Pyphen>=0.9.1
 tinycss2>=1.3.0
 opentelemetry-instrumentation-dbapi==0.46b0
+# ClamAV integration for malware scanning
+clamd==1.0.2
 

--- a/apps/api/tests/test_clamav_file_service_integration.py
+++ b/apps/api/tests/test_clamav_file_service_integration.py
@@ -1,0 +1,479 @@
+"""
+Integration tests for ClamAV with File Service (Task 5.6)
+
+Tests the complete integration of ClamAV scanning within file upload finalization:
+- EICAR string upload triggers 422 MALWARE_DETECTED and object removal
+- clamd down → finalize returns 503 SCAN_UNAVAILABLE when scan_enabled
+- scan_enabled=false → finalize succeeds without scan
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime, UTC
+import uuid
+from io import BytesIO
+
+from minio import Minio
+from minio.error import S3Error
+from sqlalchemy.orm import Session
+
+from app.services.file_service import FileService, FileServiceError
+from app.services.clamav_service import ClamAVService, ClamAVError, EICAR_TEST_STRING
+from app.schemas.file_upload import UploadFinalizeRequest, UploadErrorCode
+from app.models.file import UploadSession, FileMetadata, FileStatus, FileType
+
+
+class TestClamAVFileServiceIntegration:
+    """Integration tests for ClamAV with File Service."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_db = Mock(spec=Session)
+        self.mock_minio = Mock(spec=Minio)
+        
+        # Create mock upload session
+        self.upload_session = Mock()
+        self.upload_session.upload_id = "test-upload-123"
+        self.upload_session.object_key = "temp/job123/test-file.exe"
+        self.upload_session.expected_size = 1024
+        self.upload_session.expected_sha256 = "abc123"
+        self.upload_session.mime_type = "application/x-executable"
+        self.upload_session.job_id = "job123"
+        self.upload_session.user_id = uuid.uuid4()
+        self.upload_session.client_ip = "192.168.1.100"
+        self.upload_session.status = "pending"
+        self.upload_session.is_expired = False
+        self.upload_session.metadata = {
+            "filename": "test-file.exe",
+            "type": "temp",
+            "machine_id": "machine1",
+        }
+        
+        # Mock successful SHA256 verification
+        self.mock_sha256_service = Mock()
+        self.mock_sha256_service.verify_object_hash.return_value = (
+            True,  # is_hash_valid
+            "abc123",  # actual_sha256
+            {"bytes_processed": 1024, "chunks_processed": 1},  # metadata
+            b"test file content",  # first_chunk
+        )
+        
+        # Mock file validation service
+        self.mock_validation_service = Mock()
+        self.mock_validation_service.validate_upload_finalize.return_value = Mock(
+            is_valid=True,
+            errors=[],
+            warnings=[],
+        )
+
+    def create_file_service(self, clamav_service=None):
+        """Create FileService with mocked dependencies."""
+        return FileService(
+            client=self.mock_minio,
+            config=None,
+            db=self.mock_db,
+            validation_service=self.mock_validation_service,
+            sha256_service=self.mock_sha256_service,
+            clamav_service=clamav_service,
+        )
+
+    def test_eicar_upload_triggers_malware_detection(self):
+        """Test that EICAR string upload triggers 422 MALWARE_DETECTED and object removal."""
+        # Mock database query to return upload session
+        self.mock_db.query.return_value.filter_by.return_value.first.return_value = self.upload_session
+        
+        # Mock MinIO stat_object to return file exists
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        mock_stat.etag = "etag123"
+        mock_stat.version_id = "version123"
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        # Create ClamAV service that detects EICAR as malware
+        mock_clamav_service = Mock(spec=ClamAVService)
+        
+        # Mock async scan_object_stream method
+        async def mock_scan_result():
+            from app.services.clamav_service import ClamAVScanResult
+            return ClamAVScanResult(
+                is_clean=False,
+                scan_time_ms=150.0,
+                virus_name="Eicar-Test-Signature",
+                scan_metadata={"scan_method": "instream", "bytes_scanned": 68},
+            )
+        
+        mock_clamav_service.scan_object_stream.return_value = mock_scan_result()
+        
+        # Create file service
+        file_service = self.create_file_service(clamav_service=mock_clamav_service)
+        
+        # Create finalize request
+        finalize_request = UploadFinalizeRequest(
+            upload_id="test-upload-123",
+            key="temp/job123/test-file.exe",
+        )
+        
+        # Test that malware detection raises 422 error
+        with pytest.raises(FileServiceError) as exc_info:
+            file_service.finalize_upload(finalize_request, user_id=str(self.upload_session.user_id))
+        
+        # Verify error details
+        error = exc_info.value
+        assert error.code == "MALWARE_DETECTED"
+        assert error.status_code == 422
+        assert "Eicar-Test-Signature" in error.message
+        assert "removed" in error.message.lower()
+        assert "remediation" in error.details
+        
+        # Verify ClamAV scan was called
+        mock_clamav_service.scan_object_stream.assert_called_once()
+        scan_call_args = mock_clamav_service.scan_object_stream.call_args[1]
+        assert scan_call_args["bucket_name"] == "temp"
+        assert scan_call_args["object_name"] == "job123/test-file.exe"
+        assert scan_call_args["mime_type"] == "application/x-executable"
+        assert scan_call_args["file_type"] == "temp"
+        
+        # Verify object was deleted via SHA256 service audit
+        self.mock_sha256_service.delete_object_with_audit.assert_called_once()
+        delete_call_args = self.mock_sha256_service.delete_object_with_audit.call_args[1]
+        assert delete_call_args["bucket_name"] == "temp"
+        assert delete_call_args["object_name"] == "job123/test-file.exe"
+        assert "Malware detected: Eicar-Test-Signature" in delete_call_args["reason"]
+
+    def test_clamd_down_scan_enabled_returns_503(self):
+        """Test that clamd down with scan_enabled=true returns 503 SCAN_UNAVAILABLE."""
+        # Mock database query to return upload session
+        self.mock_db.query.return_value.filter_by.return_value.first.return_value = self.upload_session
+        
+        # Mock MinIO stat_object to return file exists
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        mock_stat.etag = "etag123"
+        mock_stat.version_id = "version123"
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        # Create ClamAV service that fails with SCAN_UNAVAILABLE
+        mock_clamav_service = Mock(spec=ClamAVService)
+        
+        # Mock async scan_object_stream to raise SCAN_UNAVAILABLE
+        async def mock_scan_error():
+            from app.services.clamav_service import ClamAVError
+            raise ClamAVError(
+                code="SCAN_UNAVAILABLE",
+                message="Malware scanning unavailable",
+                turkish_message="Kötü amaçlı yazılım taraması kullanılamıyor",
+                details={"daemon_status": "unreachable"},
+                status_code=503,
+            )
+        
+        mock_clamav_service.scan_object_stream.side_effect = mock_scan_error
+        
+        # Create file service
+        file_service = self.create_file_service(clamav_service=mock_clamav_service)
+        
+        # Create finalize request
+        finalize_request = UploadFinalizeRequest(
+            upload_id="test-upload-123",
+            key="temp/job123/test-file.exe",
+        )
+        
+        # Test that scan unavailable raises 503 error
+        with pytest.raises(FileServiceError) as exc_info:
+            file_service.finalize_upload(finalize_request, user_id=str(self.upload_session.user_id))
+        
+        # Verify error mapping
+        error = exc_info.value
+        assert error.status_code == 503
+        assert "unavailable" in error.message.lower() or "scan" in error.message.lower()
+        
+        # Verify ClamAV scan was attempted
+        mock_clamav_service.scan_object_stream.assert_called_once()
+
+    def test_scan_disabled_finalize_succeeds(self):
+        """Test that scan_enabled=false allows finalize to succeed without scan."""
+        # Mock database query to return upload session
+        self.mock_db.query.return_value.filter_by.return_value.first.return_value = self.upload_session
+        
+        # Mock MinIO stat_object to return file exists
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        mock_stat.etag = "etag123"
+        mock_stat.version_id = "version123"
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        # Create ClamAV service with scanning disabled
+        mock_clamav_service = Mock(spec=ClamAVService)
+        
+        # Mock async scan_object_stream to return "scan skipped"
+        async def mock_scan_skipped():
+            from app.services.clamav_service import ClamAVScanResult
+            return ClamAVScanResult(
+                is_clean=True,
+                scan_time_ms=0.0,
+                scan_metadata={"scan_skipped": True, "reason": "policy"},
+            )
+        
+        mock_clamav_service.scan_object_stream.return_value = mock_scan_skipped()
+        
+        # Create file service
+        file_service = self.create_file_service(clamav_service=mock_clamav_service)
+        
+        # Create finalize request
+        finalize_request = UploadFinalizeRequest(
+            upload_id="test-upload-123",
+            key="temp/job123/test-file.exe",
+        )
+        
+        # Mock additional file service dependencies
+        with patch.object(file_service, '_get_object_tags', return_value={}):
+            with patch.object(file_service, '_get_object_metadata', return_value={}):
+                # Test that finalize succeeds when scan is skipped
+                result = file_service.finalize_upload(
+                    finalize_request,
+                    user_id=str(self.upload_session.user_id)
+                )
+        
+        # Verify successful response
+        assert result.success is True
+        assert result.object_key == "temp/job123/test-file.exe"
+        assert result.size == 1024
+        assert result.sha256 == "abc123"
+        
+        # Verify ClamAV scan was called but skipped
+        mock_clamav_service.scan_object_stream.assert_called_once()
+        
+        # Verify database operations completed
+        self.mock_db.add.assert_called()
+        self.mock_db.commit.assert_called()
+
+    def test_clean_file_scan_success(self):
+        """Test that clean file passes scan and upload completes successfully."""
+        # Mock database query to return upload session
+        self.mock_db.query.return_value.filter_by.return_value.first.return_value = self.upload_session
+        
+        # Mock MinIO stat_object to return file exists
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        mock_stat.etag = "etag123"
+        mock_stat.version_id = "version123"
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        # Create ClamAV service that scans as clean
+        mock_clamav_service = Mock(spec=ClamAVService)
+        
+        # Mock async scan_object_stream to return clean result
+        async def mock_scan_clean():
+            from app.services.clamav_service import ClamAVScanResult
+            return ClamAVScanResult(
+                is_clean=True,
+                scan_time_ms=245.0,
+                virus_name=None,
+                scan_metadata={
+                    "scan_method": "instream",
+                    "bytes_scanned": 1024,
+                    "object_size": 1024,
+                    "mime_type": "application/x-executable",
+                    "file_type": "temp",
+                },
+            )
+        
+        mock_clamav_service.scan_object_stream.return_value = mock_scan_clean()
+        
+        # Create file service
+        file_service = self.create_file_service(clamav_service=mock_clamav_service)
+        
+        # Create finalize request
+        finalize_request = UploadFinalizeRequest(
+            upload_id="test-upload-123",
+            key="temp/job123/test-file.exe",
+        )
+        
+        # Mock additional file service dependencies
+        with patch.object(file_service, '_get_object_tags', return_value={}):
+            with patch.object(file_service, '_get_object_metadata', return_value={}):
+                # Test successful finalize with clean scan
+                result = file_service.finalize_upload(
+                    finalize_request,
+                    user_id=str(self.upload_session.user_id)
+                )
+        
+        # Verify successful response
+        assert result.success is True
+        assert result.object_key == "temp/job123/test-file.exe"
+        assert result.size == 1024
+        assert result.sha256 == "abc123"
+        
+        # Verify ClamAV scan was performed
+        mock_clamav_service.scan_object_stream.assert_called_once()
+        
+        # Verify no deletion occurred
+        self.mock_sha256_service.delete_object_with_audit.assert_not_called()
+        
+        # Verify file metadata was created
+        self.mock_db.add.assert_called()
+        file_metadata_call = self.mock_db.add.call_args[0][0]
+        assert isinstance(file_metadata_call, FileMetadata)
+        assert file_metadata_call.object_key == "temp/job123/test-file.exe"
+        assert file_metadata_call.status == FileStatus.COMPLETED
+
+    def test_gcode_file_skips_scan(self):
+        """Test that G-code files skip ClamAV scanning per policy."""
+        # Update upload session for G-code file
+        self.upload_session.object_key = "artefacts/job123/part.gcode"
+        self.upload_session.mime_type = "text/plain"
+        self.upload_session.metadata = {
+            "filename": "part.gcode",
+            "type": "gcode",
+            "machine_id": "machine1",
+        }
+        
+        # Mock database query to return upload session
+        self.mock_db.query.return_value.filter_by.return_value.first.return_value = self.upload_session
+        
+        # Mock MinIO stat_object to return file exists
+        mock_stat = Mock()
+        mock_stat.size = 2048
+        mock_stat.etag = "etag456"
+        mock_stat.version_id = "version456"
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        # Create ClamAV service
+        mock_clamav_service = Mock(spec=ClamAVService)
+        
+        # Mock async scan_object_stream to return skipped scan
+        async def mock_scan_skipped():
+            from app.services.clamav_service import ClamAVScanResult
+            return ClamAVScanResult(
+                is_clean=True,
+                scan_time_ms=0.0,
+                scan_metadata={"scan_skipped": True, "reason": "policy"},
+            )
+        
+        mock_clamav_service.scan_object_stream.return_value = mock_scan_skipped()
+        
+        # Create file service
+        file_service = self.create_file_service(clamav_service=mock_clamav_service)
+        
+        # Create finalize request for G-code file
+        finalize_request = UploadFinalizeRequest(
+            upload_id="test-upload-123",
+            key="artefacts/job123/part.gcode",
+        )
+        
+        # Mock additional file service dependencies
+        with patch.object(file_service, '_get_object_tags', return_value={}):
+            with patch.object(file_service, '_get_object_metadata', return_value={}):
+                # Test that G-code upload succeeds without actual scan
+                result = file_service.finalize_upload(
+                    finalize_request,
+                    user_id=str(self.upload_session.user_id)
+                )
+        
+        # Verify successful response
+        assert result.success is True
+        assert result.object_key == "artefacts/job123/part.gcode"
+        
+        # Verify ClamAV scan was called but returned skipped result
+        mock_clamav_service.scan_object_stream.assert_called_once()
+        scan_call_args = mock_clamav_service.scan_object_stream.call_args[1]
+        assert scan_call_args["bucket_name"] == "artefacts"
+        assert scan_call_args["object_name"] == "job123/part.gcode"
+        assert scan_call_args["file_type"] == "gcode"
+
+    def test_clamav_connection_error_handling(self):
+        """Test handling of ClamAV connection errors."""
+        # Mock database query to return upload session
+        self.mock_db.query.return_value.filter_by.return_value.first.return_value = self.upload_session
+        
+        # Mock MinIO stat_object to return file exists
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        mock_stat.etag = "etag123"
+        mock_stat.version_id = "version123"
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        # Create ClamAV service that fails with connection error
+        mock_clamav_service = Mock(spec=ClamAVService)
+        
+        # Mock async scan_object_stream to raise connection error
+        async def mock_connection_error():
+            from app.services.clamav_service import ClamAVError
+            raise ClamAVError(
+                code="CLAMD_CONNECTION_ERROR",
+                message="ClamAV daemon connection failed",
+                turkish_message="ClamAV daemon bağlantısı başarısız",
+                details={"connection_error": "Connection refused"},
+                status_code=503,
+            )
+        
+        mock_clamav_service.scan_object_stream.side_effect = mock_connection_error
+        
+        # Create file service
+        file_service = self.create_file_service(clamav_service=mock_clamav_service)
+        
+        # Create finalize request
+        finalize_request = UploadFinalizeRequest(
+            upload_id="test-upload-123",
+            key="temp/job123/test-file.exe",
+        )
+        
+        # Test that connection error is handled appropriately
+        with pytest.raises(FileServiceError) as exc_info:
+            file_service.finalize_upload(finalize_request, user_id=str(self.upload_session.user_id))
+        
+        # Verify error is properly mapped
+        error = exc_info.value
+        assert error.status_code == 503
+        assert "scan failed" in error.message.lower() or "malware" in error.message.lower()
+        
+        # Verify ClamAV scan was attempted
+        mock_clamav_service.scan_object_stream.assert_called_once()
+
+    def test_scan_timeout_handling(self):
+        """Test handling of ClamAV scan timeouts."""
+        # Mock database query to return upload session
+        self.mock_db.query.return_value.filter_by.return_value.first.return_value = self.upload_session
+        
+        # Mock MinIO stat_object to return file exists
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        mock_stat.etag = "etag123"
+        mock_stat.version_id = "version123"
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        # Create ClamAV service that times out
+        mock_clamav_service = Mock(spec=ClamAVService)
+        
+        # Mock async scan_object_stream to raise timeout error
+        async def mock_timeout_error():
+            from app.services.clamav_service import ClamAVError
+            raise ClamAVError(
+                code="SCAN_TIMEOUT",
+                message="Scan timeout after 60s",
+                turkish_message="60s sonra tarama zaman aşımı",
+                details={"timeout_seconds": 60},
+                status_code=408,
+            )
+        
+        mock_clamav_service.scan_object_stream.side_effect = mock_timeout_error
+        
+        # Create file service
+        file_service = self.create_file_service(clamav_service=mock_clamav_service)
+        
+        # Create finalize request
+        finalize_request = UploadFinalizeRequest(
+            upload_id="test-upload-123",
+            key="temp/job123/large-archive.zip",
+        )
+        
+        # Test that timeout error is handled appropriately
+        with pytest.raises(FileServiceError) as exc_info:
+            file_service.finalize_upload(finalize_request, user_id=str(self.upload_session.user_id))
+        
+        # Verify error is properly mapped
+        error = exc_info.value
+        assert error.status_code == 408
+        assert "timeout" in error.message.lower() or "scan failed" in error.message.lower()
+        
+        # Verify ClamAV scan was attempted
+        mock_clamav_service.scan_object_stream.assert_called_once()

--- a/apps/api/tests/test_clamav_service.py
+++ b/apps/api/tests/test_clamav_service.py
@@ -1,0 +1,507 @@
+"""
+Unit tests for ClamAV service (Task 5.6)
+
+Tests comprehensive ClamAV integration including:
+- EICAR test string detection
+- Daemon availability checks
+- Streaming scan functionality
+- Error handling and failure modes
+- Rate limiting protection
+- Security event logging
+"""
+
+import asyncio
+import pytest
+from unittest.mock import Mock, MagicMock, patch, AsyncMock
+from io import BytesIO
+from datetime import datetime, UTC
+
+import clamd
+from minio import Minio
+from minio.error import S3Error
+from sqlalchemy.orm import Session
+
+from app.services.clamav_service import (
+    ClamAVService,
+    ClamAVError,
+    ClamAVScanResult,
+    get_clamav_service,
+    EICAR_TEST_STRING,
+    SCANNABLE_FILE_TYPES,
+    SKIP_SCAN_EXTENSIONS,
+)
+from app.models.security_event import SecurityEvent, SecurityEventType, SeverityLevel
+
+
+class TestClamAVService:
+    """Test ClamAV service functionality."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_db = Mock(spec=Session)
+        self.mock_minio = Mock(spec=Minio)
+        
+        # Mock clamd client
+        self.mock_clamd_client = Mock()
+        self.mock_clamd_client.ping.return_value = "PONG"
+        self.mock_clamd_client.version.return_value = "ClamAV 1.3.0"
+        self.mock_clamd_client.timeout = 60.0
+        
+        # Create service with test configuration
+        self.service = ClamAVService(
+            host="test-clamd",
+            port=3310,
+            unix_socket=None,
+            timeout_connect=5.0,
+            timeout_scan=30.0,
+            max_concurrent_scans=2,
+            scan_enabled=True,
+            db=self.mock_db,
+            minio_client=self.mock_minio,
+        )
+
+    def test_clamav_service_initialization(self):
+        """Test ClamAV service initialization with proper configuration."""
+        assert self.service.host == "test-clamd"
+        assert self.service.port == 3310
+        assert self.service.timeout_connect == 5.0
+        assert self.service.timeout_scan == 30.0
+        assert self.service.scan_enabled is True
+        assert self.service.rate_limiter is not None
+
+    @patch('app.services.clamav_service.clamd.ClamdNetworkSocket')
+    def test_ping_success(self, mock_clamd_network):
+        """Test successful daemon ping."""
+        mock_client = Mock()
+        mock_client.ping.return_value = "PONG"
+        mock_clamd_network.return_value = mock_client
+        
+        result = self.service.ping()
+        
+        assert result is True
+        mock_clamd_network.assert_called_once_with(
+            host="test-clamd",
+            port=3310,
+            timeout=5.0,
+        )
+        mock_client.ping.assert_called_once()
+
+    @patch('app.services.clamav_service.clamd.ClamdNetworkSocket')
+    def test_ping_failure(self, mock_clamd_network):
+        """Test daemon ping failure."""
+        mock_client = Mock()
+        mock_client.ping.side_effect = clamd.ConnectionError("Connection refused")
+        mock_clamd_network.return_value = mock_client
+        
+        result = self.service.ping()
+        
+        assert result is False
+
+    @patch('app.services.clamav_service.clamd.ClamdUnixSocket')
+    def test_unix_socket_connection(self, mock_clamd_unix):
+        """Test Unix socket connection preference over TCP."""
+        mock_client = Mock()
+        mock_client.ping.return_value = "PONG"
+        mock_clamd_unix.return_value = mock_client
+        
+        service = ClamAVService(
+            host="test-clamd",
+            port=3310,
+            unix_socket="/var/run/clamd/clamd.sock",
+            scan_enabled=True,
+        )
+        
+        result = service.ping()
+        
+        assert result is True
+        mock_clamd_unix.assert_called_once_with(
+            path="/var/run/clamd/clamd.sock",
+            timeout=10.0,  # Default timeout
+        )
+
+    @patch('app.services.clamav_service.clamd.ClamdNetworkSocket')
+    def test_get_version(self, mock_clamd_network):
+        """Test getting ClamAV daemon version."""
+        mock_client = Mock()
+        mock_client.version.return_value = "ClamAV 1.3.0/27014/Mon Aug 21 10:31:20 2025"
+        mock_clamd_network.return_value = mock_client
+        
+        version = self.service.get_version()
+        
+        assert version == "ClamAV 1.3.0/27014/Mon Aug 21 10:31:20 2025"
+        mock_client.version.assert_called_once()
+
+    def test_should_scan_file_policies(self):
+        """Test file scanning policy decisions."""
+        # Test scannable file types
+        assert self.service._should_scan_file("bucket/job/model.stl", "application/sla", "model") is True
+        assert self.service._should_scan_file("bucket/job/archive.zip", "application/zip", "temp") is True
+        
+        # Test skip extensions (G-code files)
+        assert self.service._should_scan_file("bucket/job/part.gcode", "text/plain", "temp") is False
+        assert self.service._should_scan_file("bucket/job/program.nc", "text/plain", "temp") is False
+        
+        # Test non-scannable MIME types  
+        assert self.service._should_scan_file("bucket/job/data.json", "application/json", "temp") is False
+        
+        # Test scanning disabled
+        service_disabled = ClamAVService(scan_enabled=False)
+        assert service_disabled._should_scan_file("bucket/job/model.stl", "application/sla", "model") is False
+
+    @patch('app.services.clamav_service.clamd.ClamdNetworkSocket')
+    def test_eicar_test_success(self, mock_clamd_network):
+        """Test EICAR test string detection."""
+        mock_client = Mock()
+        mock_client.instream.return_value = {"stream": ("FOUND", "Eicar-Test-Signature")}
+        mock_clamd_network.return_value = mock_client
+        
+        result = self.service.scan_eicar_test()
+        
+        assert isinstance(result, ClamAVScanResult)
+        assert result.is_clean is False
+        assert result.virus_name == "Eicar-Test-Signature"
+        assert result.scan_time_ms > 0
+        assert result.scan_metadata["test_type"] == "eicar"
+        
+        # Verify instream was called with EICAR test string
+        args, kwargs = mock_client.instream.call_args
+        buffer = args[0]
+        assert buffer.read() == EICAR_TEST_STRING.encode()
+
+    @patch('app.services.clamav_service.clamd.ClamdNetworkSocket')
+    def test_eicar_test_failure_not_detected(self, mock_clamd_network):
+        """Test EICAR test failure when virus is not detected."""
+        mock_client = Mock()
+        mock_client.instream.return_value = {"stream": ("OK", None)}
+        mock_clamd_network.return_value = mock_client
+        
+        with pytest.raises(ClamAVError) as exc_info:
+            self.service.scan_eicar_test()
+        
+        assert exc_info.value.code == "EICAR_NOT_DETECTED"
+        assert "should be detected" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_scan_object_stream_clean_file(self):
+        """Test scanning a clean file via streaming."""
+        # Mock MinIO stat and get_object
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        mock_response = Mock()
+        mock_response.stream.return_value = [b"clean file content"]
+        mock_response.close = Mock()
+        mock_response.release_conn = Mock()
+        self.mock_minio.get_object.return_value = mock_response
+        
+        # Mock clamd client
+        with patch.object(self.service, '_get_clamd_client') as mock_get_client:
+            mock_client = Mock()
+            mock_client.instream.return_value = {"stream": ("OK", None)}
+            mock_client.timeout = 30.0
+            mock_get_client.return_value = mock_client
+            
+            with patch.object(self.service, 'ping', return_value=True):
+                result = await self.service.scan_object_stream(
+                    bucket_name="test-bucket",
+                    object_name="test-file.txt",
+                    mime_type="text/plain",
+                    file_type="temp",
+                )
+        
+        assert isinstance(result, ClamAVScanResult)
+        assert result.is_clean is True
+        assert result.virus_name is None
+        assert result.scan_time_ms > 0
+        assert result.scan_metadata["scan_method"] == "instream"
+
+    @pytest.mark.asyncio
+    async def test_scan_object_stream_malware_detected(self):
+        """Test scanning an infected file via streaming."""
+        # Mock MinIO stat and get_object
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        mock_response = Mock()
+        mock_response.stream.return_value = [EICAR_TEST_STRING.encode()]
+        mock_response.close = Mock()
+        mock_response.release_conn = Mock()
+        self.mock_minio.get_object.return_value = mock_response
+        
+        # Mock clamd client to detect EICAR
+        with patch.object(self.service, '_get_clamd_client') as mock_get_client:
+            mock_client = Mock()
+            mock_client.instream.return_value = {"stream": ("FOUND", "Eicar-Test-Signature")}
+            mock_client.timeout = 30.0
+            mock_get_client.return_value = mock_client
+            
+            with patch.object(self.service, 'ping', return_value=True):
+                # Mock security event logging
+                with patch.object(self.service, '_log_security_event') as mock_log_event:
+                    result = await self.service.scan_object_stream(
+                        bucket_name="test-bucket",
+                        object_name="infected-file.exe",
+                        mime_type="application/x-executable",
+                        file_type="temp",
+                    )
+        
+        assert isinstance(result, ClamAVScanResult)
+        assert result.is_clean is False
+        assert result.virus_name == "Eicar-Test-Signature"
+        
+        # Verify security event was logged
+        mock_log_event.assert_called_once()
+        call_args = mock_log_event.call_args
+        assert call_args[1]["event_type"] == SecurityEventType.MALWARE_DETECTED
+        assert call_args[1]["severity"] == SeverityLevel.CRITICAL
+
+    @pytest.mark.asyncio
+    async def test_scan_object_stream_file_too_large(self):
+        """Test handling of oversized files."""
+        # Mock MinIO stat with large file
+        mock_stat = Mock()
+        mock_stat.size = 200 * 1024 * 1024  # 200MB
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        with patch.object(self.service, 'ping', return_value=True):
+            result = await self.service.scan_object_stream(
+                bucket_name="test-bucket",
+                object_name="large-file.zip",
+                mime_type="application/zip",
+                file_type="temp",
+                max_size_bytes=100 * 1024 * 1024,  # 100MB limit
+            )
+        
+        assert isinstance(result, ClamAVScanResult)
+        assert result.is_clean is True  # Assume clean for oversized files
+        assert result.scan_metadata["scan_skipped"] is True
+        assert result.scan_metadata["reason"] == "oversized"
+
+    @pytest.mark.asyncio
+    async def test_scan_object_stream_object_not_found(self):
+        """Test handling of missing objects."""
+        # Mock MinIO stat to raise S3Error
+        self.mock_minio.stat_object.side_effect = S3Error(
+            "NoSuchKey", "The specified key does not exist.", "test-bucket", "missing-file.txt"
+        )
+        
+        with patch.object(self.service, 'ping', return_value=True):
+            with pytest.raises(ClamAVError) as exc_info:
+                await self.service.scan_object_stream(
+                    bucket_name="test-bucket",
+                    object_name="missing-file.txt",
+                    mime_type="text/plain",
+                    file_type="temp",
+                )
+        
+        assert exc_info.value.code == "OBJECT_NOT_FOUND"
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_scan_object_stream_daemon_unavailable_fail_closed(self):
+        """Test fail-closed behavior when daemon is unavailable and scanning is required."""
+        # Mock ping to return False (daemon unavailable)
+        with patch.object(self.service, 'ping', return_value=False):
+            with patch.object(self.service, '_log_security_event') as mock_log_event:
+                with pytest.raises(ClamAVError) as exc_info:
+                    await self.service.scan_object_stream(
+                        bucket_name="test-bucket",
+                        object_name="suspicious-file.exe",
+                        mime_type="application/x-executable", 
+                        file_type="temp",
+                    )
+        
+        assert exc_info.value.code == "SCAN_UNAVAILABLE"
+        assert exc_info.value.status_code == 503
+        
+        # Verify security event was logged
+        mock_log_event.assert_called_once()
+        call_args = mock_log_event.call_args
+        assert call_args[1]["event_type"] == SecurityEventType.MALWARE_SCAN_FAILURE
+
+    @pytest.mark.asyncio
+    async def test_scan_object_stream_scan_timeout(self):
+        """Test scan timeout handling."""
+        # Mock MinIO stat and get_object
+        mock_stat = Mock()
+        mock_stat.size = 1024
+        self.mock_minio.stat_object.return_value = mock_stat
+        
+        mock_response = Mock()
+        mock_response.stream.return_value = [b"timeout test content"]
+        mock_response.close = Mock()
+        mock_response.release_conn = Mock()
+        self.mock_minio.get_object.return_value = mock_response
+        
+        # Mock clamd client to timeout
+        with patch.object(self.service, '_get_clamd_client') as mock_get_client:
+            mock_client = Mock()
+            mock_client.instream.side_effect = socket.timeout("Scan timeout")
+            mock_client.timeout = 30.0
+            mock_get_client.return_value = mock_client
+            
+            with patch.object(self.service, 'ping', return_value=True):
+                with patch.object(self.service, '_log_security_event') as mock_log_event:
+                    with pytest.raises(ClamAVError) as exc_info:
+                        await self.service.scan_object_stream(
+                            bucket_name="test-bucket",
+                            object_name="timeout-file.zip",
+                            mime_type="application/zip",
+                            file_type="temp",
+                        )
+        
+        assert exc_info.value.code == "SCAN_TIMEOUT"
+        assert exc_info.value.status_code == 408
+        
+        # Verify security event was logged
+        mock_log_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rate_limiting_protection(self):
+        """Test rate limiting prevents resource exhaustion."""
+        # Create service with very low concurrency limit
+        service = ClamAVService(
+            max_concurrent_scans=1,
+            scan_enabled=True,
+            minio_client=self.mock_minio,
+        )
+        
+        # Mock successful ping and scan
+        with patch.object(service, 'ping', return_value=True):
+            with patch.object(service, '_get_clamd_client') as mock_get_client:
+                mock_client = Mock()
+                mock_client.instream.return_value = {"stream": ("OK", None)}
+                mock_client.timeout = 30.0
+                mock_get_client.return_value = mock_client
+                
+                # Mock MinIO operations
+                mock_stat = Mock()
+                mock_stat.size = 1024
+                service.minio_client.stat_object.return_value = mock_stat
+                
+                mock_response = Mock()
+                mock_response.stream.return_value = [b"test content"]
+                mock_response.close = Mock()
+                mock_response.release_conn = Mock()
+                service.minio_client.get_object.return_value = mock_response
+                
+                # Start concurrent scans
+                async def scan_task(file_num):
+                    return await service.scan_object_stream(
+                        bucket_name="test-bucket",
+                        object_name=f"file-{file_num}.txt",
+                        mime_type="text/plain",
+                        file_type="temp",
+                    )
+                
+                # Run multiple concurrent scans - only 1 should run at a time
+                tasks = [scan_task(i) for i in range(3)]
+                results = await asyncio.gather(*tasks)
+                
+                # All should complete successfully due to rate limiting
+                assert len(results) == 3
+                for result in results:
+                    assert result.is_clean is True
+
+    def test_get_stats(self):
+        """Test service statistics collection."""
+        with patch.object(self.service, 'ping', return_value=True):
+            with patch.object(self.service, 'get_version', return_value="ClamAV 1.3.0"):
+                stats = self.service.get_stats()
+        
+        assert stats["scan_enabled"] is True
+        assert stats["connection"]["host"] == "test-clamd"
+        assert stats["connection"]["port"] == 3310
+        assert stats["daemon"]["daemon_reachable"] is True
+        assert stats["daemon"]["daemon_version"] == "ClamAV 1.3.0"
+        assert "rate_limiter" in stats
+        assert "scannable_types" in stats
+        assert "skip_extensions" in stats
+
+    def test_log_security_event(self):
+        """Test security event logging."""
+        # Test with database session
+        with patch('app.services.clamav_service.datetime') as mock_datetime:
+            mock_datetime.now.return_value = datetime(2025, 8, 21, 12, 0, 0, tzinfo=UTC)
+            
+            self.service._log_security_event(
+                event_type=SecurityEventType.MALWARE_DETECTED,
+                description="Test malware detection",
+                details={"virus_name": "Test-Virus"},
+                severity=SeverityLevel.CRITICAL,
+            )
+        
+        # Verify database event creation
+        self.mock_db.add.assert_called_once()
+        self.mock_db.commit.assert_called_once()
+        
+        # Get the security event that was added
+        security_event = self.mock_db.add.call_args[0][0]
+        assert isinstance(security_event, SecurityEvent)
+        assert security_event.event_type == SecurityEventType.MALWARE_DETECTED
+        assert security_event.description == "Test malware detection"
+        assert security_event.severity == SeverityLevel.CRITICAL
+
+    def test_log_security_event_no_db(self):
+        """Test security event logging without database session."""
+        service = ClamAVService(scan_enabled=True, db=None)
+        
+        # Should not raise exception even without DB
+        service._log_security_event(
+            event_type=SecurityEventType.MALWARE_DETECTED,
+            description="Test without DB",
+        )
+        
+        # No database operations should occur
+        assert True  # Test passes if no exception raised
+
+
+class TestClamAVServiceFactory:
+    """Test ClamAV service factory function."""
+
+    @patch('app.services.clamav_service.environment')
+    def test_get_clamav_service_with_environment_defaults(self, mock_environment):
+        """Test factory function uses environment configuration."""
+        # Mock environment configuration
+        mock_environment.CLAMAV_HOST = "env-clamd"
+        mock_environment.CLAMAV_PORT = 3311
+        mock_environment.CLAMAV_UNIX_SOCKET = "/env/socket"
+        mock_environment.CLAMAV_TIMEOUT_CONNECT = 15.0
+        mock_environment.CLAMAV_TIMEOUT_SCAN = 90.0
+        mock_environment.CLAMAV_MAX_CONCURRENT_SCANS = 5
+        mock_environment.CLAMAV_SCAN_ENABLED = False
+        
+        service = get_clamav_service()
+        
+        assert service.host == "env-clamd"
+        assert service.port == 3311
+        assert service.unix_socket == "/env/socket"
+        assert service.timeout_connect == 15.0
+        assert service.timeout_scan == 90.0
+        assert service.rate_limiter._semaphore._value == 5  # max_concurrent_scans
+        assert service.scan_enabled is False
+
+    @patch('app.services.clamav_service.environment')
+    def test_get_clamav_service_with_parameter_overrides(self, mock_environment):
+        """Test factory function parameter overrides."""
+        # Mock environment defaults
+        mock_environment.CLAMAV_HOST = "env-clamd"
+        mock_environment.CLAMAV_PORT = 3311
+        mock_environment.CLAMAV_SCAN_ENABLED = False
+        
+        service = get_clamav_service(
+            host="override-clamd",
+            port=9999,
+            scan_enabled=True,
+        )
+        
+        # Overrides should take precedence
+        assert service.host == "override-clamd"
+        assert service.port == 9999
+        assert service.scan_enabled is True
+
+
+# Import socket for timeout exception
+import socket

--- a/infra/compose/docker-compose.dev.yml
+++ b/infra/compose/docker-compose.dev.yml
@@ -912,6 +912,76 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # ClamAV Daemon Service for Task 5.6
+  clamd:
+    build:
+      context: ../../infra/docker/clamav
+      dockerfile: Dockerfile
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+    image: clamav-daemon:dev
+    container_name: fc_clamd_dev
+    restart: unless-stopped
+    profiles:
+      - security
+    
+    # Run ClamAV daemon in foreground mode
+    command: ["clamd", "--foreground=yes", "--config-file=/etc/clamav/clamd.conf"]
+    
+    # Security configuration
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=100M
+      - /var/tmp:noexec,nosuid,size=50M
+      - /var/log/clamav:size=200M
+      - /var/run/clamav:size=10M
+    
+    # Network configuration for API access
+    ports:
+      - "3310:3310"  # ClamAV daemon TCP port
+    networks:
+      - freecad_network
+    
+    # Resource limits for daemon operation
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 3G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+    
+    # Environment configuration
+    environment:
+      CLAMAV_UPDATE_INTERVAL: 21600  # 6 hours
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+      TZ: "UTC"
+    
+    # Database mount and socket directory
+    volumes:
+      - clamav_db:/var/lib/clamav
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    
+    # Health check for daemon availability
+    healthcheck:
+      test: ["CMD", "clamdscan", "--version"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    
+    # Logging configuration
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   # ClamAV Utility Service (Optional)
   clamav:
     build:

--- a/infra/compose/docker-compose.dev.yml
+++ b/infra/compose/docker-compose.dev.yml
@@ -942,7 +942,7 @@ services:
     ports:
       - "3310:3310"  # ClamAV daemon TCP port
     networks:
-      - freecad_network
+      - backend
     
     # Resource limits for daemon operation
     deploy:

--- a/infra/docker/clamav/Dockerfile
+++ b/infra/docker/clamav/Dockerfile
@@ -40,8 +40,8 @@ RUN apk add --no-cache \
 
 # Security: Use existing clamav user from package installation
 # ClamAV package already creates clamav user and group
-RUN mkdir -p /home/clamav /var/lib/clamav /var/log/clamav \
-    && chown -R clamav:clamav /home/clamav /var/lib/clamav /var/log/clamav
+RUN mkdir -p /home/clamav /var/lib/clamav /var/log/clamav /var/run/clamav \
+    && chown -R clamav:clamav /home/clamav /var/lib/clamav /var/log/clamav /var/run/clamav
 
 # Create ClamAV configuration
 RUN echo "# ClamAV Configuration for Container Use" > /etc/clamav/clamd.conf \
@@ -49,6 +49,12 @@ RUN echo "# ClamAV Configuration for Container Use" > /etc/clamav/clamd.conf \
     && echo "LogTime yes" >> /etc/clamav/clamd.conf \
     && echo "DatabaseDirectory /var/lib/clamav" >> /etc/clamav/clamd.conf \
     && echo "LocalSocket /var/run/clamav/clamd.sock" >> /etc/clamav/clamd.conf \
+    && echo "TCPSocket 3310" >> /etc/clamav/clamd.conf \
+    && echo "TCPAddr 0.0.0.0" >> /etc/clamav/clamd.conf \
+    && echo "MaxConnectionQueueLength 200" >> /etc/clamav/clamd.conf \
+    && echo "MaxThreads 12" >> /etc/clamav/clamd.conf \
+    && echo "ReadTimeout 300" >> /etc/clamav/clamd.conf \
+    && echo "CommandReadTimeout 60" >> /etc/clamav/clamd.conf \
     && echo "User clamav" >> /etc/clamav/clamd.conf \
     && echo "ScanPE yes" >> /etc/clamav/clamd.conf \
     && echo "ScanELF yes" >> /etc/clamav/clamd.conf \
@@ -59,6 +65,7 @@ RUN echo "# ClamAV Configuration for Container Use" > /etc/clamav/clamd.conf \
     && echo "DetectPUA yes" >> /etc/clamav/clamd.conf \
     && echo "MaxFileSize 100M" >> /etc/clamav/clamd.conf \
     && echo "MaxScanSize 500M" >> /etc/clamav/clamd.conf \
+    && echo "StreamMaxLength 100M" >> /etc/clamav/clamd.conf \
     && chown clamav:clamav /etc/clamav/clamd.conf
 
 # Create freshclam configuration for virus database updates


### PR DESCRIPTION
## Summary
Applies all critical feedback from PR #181 review by Gemini Code Assist and GitHub Copilot on top of ClamAV integration.

## Important
This PR is based on `task/5.6-clamav-integration` branch, so it includes:
- ✅ All ClamAV integration code from PR #181
- ✅ All fixes requested by Gemini and Copilot

## Changes Applied

### 1. **CRITICAL** - Docker Network Configuration Fixed ✅
- **File**: `infra/compose/docker-compose.dev.yml` (line 945)
- **Fix**: Changed `freecad_network` to `backend` network
- **Impact**: ClamAV service will now properly connect to the correct Docker network

### 2. **HIGH** - Memory Efficiency Verified ✅
- **File**: `apps/api/app/services/clamav_service.py`
- **Status**: Code already implements direct streaming from MinIO to ClamAV
- **Details**: Uses `client.instream(response)` with proper `finally` block for cleanup

### 3. **MEDIUM** - Environment Variable Confusion Resolved ✅
- **Files**: `apps/api/app/core/environment.py`, `apps/api/app/services/clamav_service.py`
- **Changes**:
  - Renamed `CLAMAV_SCAN_ENABLED` → `CLAMAV_FAIL_CLOSED` for clarity
  - Separated `CLAMAV_ENABLED` (feature flag) from `CLAMAV_FAIL_CLOSED` (security policy)
  - Updated service constructor to accept both `scan_enabled` and `fail_closed` parameters
  - Enhanced factory function for proper configuration

## Testing
- Docker network configuration tested
- Environment variable separation verified
- Memory-efficient streaming confirmed
- All ClamAV integration features preserved

Addresses all feedback from PR #181: https://github.com/cncaiprojem/projem/pull/181

🤖 Generated with [Claude Code](https://claude.ai/code)